### PR TITLE
cobs.h: add documentation for cobs_encode() and cobs_decode()

### DIFF
--- a/cobs.c
+++ b/cobs.c
@@ -25,6 +25,17 @@
  * Functions
  ****************************************************************************/
 
+/* COBS-encode a string of input bytes.
+ *
+ * dst_buf_ptr:    The buffer into which the result will be written
+ * dst_buf_len:    Length of the buffer into which the result will be written
+ * src_ptr:        The byte string to be encoded
+ * src_len         Length of the byte string to be encoded
+ *
+ * returns:        A struct containing the success status of the encoding
+ *                 operation and the length of the result (that was written to
+ *                 dst_buf_ptr)
+ */
 cobs_encode_result cobs_encode(uint8_t *dst_buf_ptr, size_t dst_buf_len, const uint8_t * src_ptr, size_t src_len)
 {
     cobs_encode_result  result              = { 0, COBS_ENCODE_OK };
@@ -111,6 +122,17 @@ cobs_encode_result cobs_encode(uint8_t *dst_buf_ptr, size_t dst_buf_len, const u
 }
 
 
+/* Decode a COBS byte string.
+ *
+ * dst_buf_ptr:    The buffer into which the result will be written
+ * dst_buf_len:    Length of the buffer into which the result will be written
+ * src_ptr:        The byte string to be decoded
+ * src_len         Length of the byte string to be decoded
+ *
+ * returns:        A struct containing the success status of the decoding
+ *                 operation and the length of the result (that was written to
+ *                 dst_buf_ptr)
+ */
 cobs_decode_result cobs_decode(uint8_t *dst_buf_ptr, size_t dst_buf_len, const uint8_t * src_ptr, size_t src_len)
 {
     cobs_decode_result  result              = { 0, COBS_DECODE_OK };

--- a/cobs.h
+++ b/cobs.h
@@ -68,9 +68,33 @@ typedef struct
 extern "C" {
 #endif
 
-cobs_encode_result cobs_encode(uint8_t *dst_buf_ptr, size_t dst_buf_len, const uint8_t * src_ptr, size_t src_len);
-cobs_decode_result cobs_decode(uint8_t *dst_buf_ptr, size_t dst_buf_len, const uint8_t * src_ptr, size_t src_len);
+/* COBS-encode a string of input bytes.
+ *
+ * dst_buf_ptr:    The buffer into which the result will be written
+ * dst_buf_len:    Length of the buffer into which the result will be written
+ * src_ptr:        The byte string to be encoded
+ * src_len         Length of the byte string to be encoded
+ *
+ * returns:        A struct containing the success status of the encoding
+ *                 operation and the length of the result (that was written to
+ *                 dst_buf_ptr)
+ */
+cobs_encode_result cobs_encode(uint8_t *dst_buf_ptr, size_t dst_buf_len,
+                               const uint8_t * src_ptr, size_t src_len);
 
+/* Decode a COBS byte string.
+ *
+ * dst_buf_ptr:    The buffer into which the result will be written
+ * dst_buf_len:    Length of the buffer into which the result will be written
+ * src_ptr:        The byte string to be decoded
+ * src_len         Length of the byte string to be decoded
+ *
+ * returns:        A struct containing the success status of the decoding
+ *                 operation and the length of the result (that was written to
+ *                 dst_buf_ptr)
+ */
+cobs_decode_result cobs_decode(uint8_t *dst_buf_ptr, size_t dst_buf_len,
+                               const uint8_t * src_ptr, size_t src_len);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/cobsr.c
+++ b/cobsr.c
@@ -25,6 +25,17 @@
  * Functions
  ****************************************************************************/
 
+/* COBS/R-encode a string of input bytes, which may save one byte of output.
+ *
+ * dst_buf_ptr:    The buffer into which the result will be written
+ * dst_buf_len:    Length of the buffer into which the result will be written
+ * src_ptr:        The byte string to be encoded
+ * src_len         Length of the byte string to be encoded
+ *
+ * returns:        A struct containing the success status of the encoding
+ *                 operation and the length of the result (that was written to
+ *                 dst_buf_ptr)
+ */
 cobsr_encode_result cobsr_encode(uint8_t *dst_buf_ptr, size_t dst_buf_len, const uint8_t * src_ptr, size_t src_len)
 {
     cobsr_encode_result result              = { 0, COBSR_ENCODE_OK };
@@ -127,6 +138,17 @@ cobsr_encode_result cobsr_encode(uint8_t *dst_buf_ptr, size_t dst_buf_len, const
 }
 
 
+/* Decode a COBS/R byte string.
+ *
+ * dst_buf_ptr:    The buffer into which the result will be written
+ * dst_buf_len:    Length of the buffer into which the result will be written
+ * src_ptr:        The byte string to be decoded
+ * src_len         Length of the byte string to be decoded
+ *
+ * returns:        A struct containing the success status of the decoding
+ *                 operation and the length of the result (that was written to
+ *                 dst_buf_ptr)
+ */
 cobsr_decode_result cobsr_decode(uint8_t *dst_buf_ptr, size_t dst_buf_len, const uint8_t * src_ptr, size_t src_len)
 {
     cobsr_decode_result result              = { 0, COBSR_DECODE_OK };

--- a/cobsr.h
+++ b/cobsr.h
@@ -67,8 +67,33 @@ typedef struct
 extern "C" {
 #endif
 
-cobsr_encode_result cobsr_encode(uint8_t *dst_buf_ptr, size_t dst_buf_len, const uint8_t * src_ptr, size_t src_len);
-cobsr_decode_result cobsr_decode(uint8_t *dst_buf_ptr, size_t dst_buf_len, const uint8_t * src_ptr, size_t src_len);
+/* COBS/R-encode a string of input bytes, which may save one byte of output.
+ *
+ * dst_buf_ptr:    The buffer into which the result will be written
+ * dst_buf_len:    Length of the buffer into which the result will be written
+ * src_ptr:        The byte string to be encoded
+ * src_len         Length of the byte string to be encoded
+ *
+ * returns:        A struct containing the success status of the encoding
+ *                 operation and the length of the result (that was written to
+ *                 dst_buf_ptr)
+ */
+cobsr_encode_result cobsr_encode(uint8_t *dst_buf_ptr, size_t dst_buf_len,
+                                 const uint8_t * src_ptr, size_t src_len);
+
+/* Decode a COBS/R byte string.
+ *
+ * dst_buf_ptr:    The buffer into which the result will be written
+ * dst_buf_len:    Length of the buffer into which the result will be written
+ * src_ptr:        The byte string to be decoded
+ * src_len         Length of the byte string to be decoded
+ *
+ * returns:        A struct containing the success status of the decoding
+ *                 operation and the length of the result (that was written to
+ *                 dst_buf_ptr)
+ */
+cobsr_decode_result cobsr_decode(uint8_t *dst_buf_ptr, size_t dst_buf_len,
+                                 const uint8_t * src_ptr, size_t src_len);
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
Add some documentation to clarify which information ends up where after en/decoding. I tried to match your comment style (going full-on Doxygen seemed a little over the top for a minimal library like this one), if you prefer a different format I'd be happy to change my PR acoordingly :)
I also added some line breaks to the function signature to match the line length hinted at by your `/*****************************************************************************` comment blocks.