### PR TITLE
Don't perform arithmetic on void pointers

### DIFF
--- a/cobs.c
+++ b/cobs.c
@@ -41,9 +41,9 @@ cobs_encode_result cobs_encode(void * dst_buf_ptr, size_t dst_buf_len,
 {
     cobs_encode_result  result              = { 0, COBS_ENCODE_OK };
     const uint8_t *     src_read_ptr        = src_ptr;
-    const uint8_t *     src_end_ptr         = src_ptr + src_len;
+    const uint8_t *     src_end_ptr         = src_read_ptr + src_len;
     uint8_t *           dst_buf_start_ptr   = dst_buf_ptr;
-    uint8_t *           dst_buf_end_ptr     = dst_buf_ptr + dst_buf_len;
+    uint8_t *           dst_buf_end_ptr     = dst_buf_start_ptr + dst_buf_len;
     uint8_t *           dst_code_write_ptr  = dst_buf_ptr;
     uint8_t *           dst_write_ptr       = dst_code_write_ptr + 1;
     uint8_t             src_byte            = 0;
@@ -141,9 +141,9 @@ cobs_decode_result cobs_decode(void * dst_buf_ptr, size_t dst_buf_len,
 {
     cobs_decode_result  result              = { 0, COBS_DECODE_OK };
     const uint8_t *     src_read_ptr        = src_ptr;
-    const uint8_t *     src_end_ptr         = src_ptr + src_len;
+    const uint8_t *     src_end_ptr         = src_read_ptr + src_len;
     uint8_t *           dst_buf_start_ptr   = dst_buf_ptr;
-    uint8_t *           dst_buf_end_ptr     = dst_buf_ptr + dst_buf_len;
+    uint8_t *           dst_buf_end_ptr     = dst_buf_start_ptr + dst_buf_len;
     uint8_t *           dst_write_ptr       = dst_buf_ptr;
     size_t              remaining_bytes;
     uint8_t             src_byte;


### PR DESCRIPTION
void* does not have a defined size (although GCC does define it as 1 due
to arithmetic on void* being common in older code bases). Since
everything internally operates on uint8_t*, use that for the arithmetic
to guarantee the desired behaviour and remove compiler warnings.